### PR TITLE
Fixes #2: Added null guard

### DIFF
--- a/lib/atom-tfs-auto.coffee
+++ b/lib/atom-tfs-auto.coffee
@@ -3,7 +3,6 @@ tfs = require 'tfs-unlock'
 module.exports = AtomTfsAuto =
 
   activate: (state) ->
-    # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     tfs.init({
       "visualStudioPath": tfs.vs2015.bit32
       });
@@ -11,6 +10,6 @@ module.exports = AtomTfsAuto =
 
   _events: ->
     atom.workspace.observeTextEditors (editor) ->
-      editor.onDidStopChanging () =>
-        if atom.workspace.getActivePaneItem().buffer.file.path?
+      editor.onDidStopChanging () ->
+        if atom.workspace.getActivePaneItem().buffer.file?.path?
           tfs.checkout([atom.workspace.getActivePaneItem().buffer.file.path])


### PR DESCRIPTION
- Null guard on atom.workspace.getActivePaneItem().buffer.file protects from a null file if the current buffer is unsaved.
- Removed the comment reference to CompositeDisposable as it is not in use in this instance.
- Changed fat arrow to thin arrow as this isn't actually required in this instance.
